### PR TITLE
[Breaking] Allow multiple git commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL "com.github.actions.color"="yellow"
 LABEL "repository"="http://github.com/srt32/git-actions"
 LABEL "homepage"="http://github.com/srt32/git-actions"
 
-RUN apk add --no-cache git bash
+RUN apk add --no-cache git
 
 ADD entrypoint.sh /
 RUN chmod +x /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Action for running git commands
 
-You can run any `git` command you need. For example, you could run `git status` like this.
+You can run any `git` commands you need. For example, you could run `git status` like this.
 
 ```hcl
 workflow "My build" {
@@ -12,6 +12,22 @@ workflow "My build" {
 
 action "git command" {
   uses = "srt32/git-actions@v0.0.3"
-  args = "git status"
+  args = ["status"]
+}
+```
+
+You can also run multiple git commands like so:
+
+```hcl
+workflow "My build" {
+  resolves = [
+    "git command",
+  ]
+  on = "push"
+}
+
+action "git command" {
+  uses = "srt32/git-actions@v0.0.3"
+  args = ["status", "show"]
 }
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,13 @@
-#!/bin/bash
-set -e
+#!/bin/sh
 
-echo "#################################################"
-echo "Starting the git Action"
-
-sh -c "$*"
-
-echo "#################################################"
-echo "Completed the git Action"
+for cmd in "$@"; do
+    echo "Running 'git $cmd'..."
+    if sh -c "git $cmd"; then
+        # no op
+        echo "Successfully ran 'git $cmd'"
+    else
+        exit_code=$?
+        echo "Failure running 'git $cmd', exited with $exit_code"
+        exit $exit_code
+    fi
+done


### PR DESCRIPTION
Allow multiple git commands to be run. It's based on [`actions/bin/sh`](https://github.com/actions/bin/blob/master/sh/entrypoint.sh).

It also prefixes the commands with `git` so you don't have to, as inspired by the official [`actions/docker`](https://github.com/actions/docker/blob/master/cli/entrypoint.sh)